### PR TITLE
[CRO-4035] Remove club vistara

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-partnerships",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "description": "Partnership information for Luxury Escapes",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,8 @@
-import { KrisFlyer, Partnership, Qantas, Velocity, Vistara } from "./partnerships";
-export { KrisFlyer, Partnership, Qantas, Velocity, Vistara };
+import { KrisFlyer, Partnership, Qantas, Velocity } from "./partnerships";
+export { KrisFlyer, Partnership, Qantas, Velocity };
 const list = [
   Qantas,
   KrisFlyer,
-  Vistara,
   Velocity,
 ];
 

--- a/src/partnerships.ts
+++ b/src/partnerships.ts
@@ -136,49 +136,6 @@ export const KrisFlyer: Partnership = {
   rewardProgramName: "KrisFlyer",
 };
 
-export const Vistara: Partnership = {
-  accountFields: [
-    "account_id",
-    "first_name",
-    "last_name",
-  ],
-  accountFieldsLabels: {
-    account_id: "Club Vistara ID",
-    first_name: "Club Vistara First Name",
-    last_name: "Club Vistara Last Name",
-  },
-  bonusPointCost: 20,
-  bonusUnit: "Point",
-  brandName: "Vistara",
-  code: "vistara",
-  color: "#582c4f",
-  confirmationText: "Your points will land in your Vistara account in 40 days.",
-  currencyCodes: [
-    "INR",
-  ],
-  hasBurn: false,
-  hasEarn: true,
-  icon: "vistara_2x_o4y0uv",
-  iconReversed: "vistara_2x_o4y0uv",
-  joinUrl: "https://www.airvistara.com/trip/partner-register/luxuryescapes",
-  landingPage: "club-vistara",
-  landingPageLogo: "Vistara-Luxury-Escapes_evlamb",
-  numberMaxLength: 14,
-  prefix: "cvp",
-  programLogo: "vistaraLogo_2x_p6p4ab",
-  programName: "Club Vistara",
-  regionCodes: [
-    "IN",
-  ],
-  reverseLogo: "VistaraLogoReverse_2x_f7a8un",
-  rewardConversion: 0.05,
-  rewardCurrency: "INR",
-  rewardEarn: 5,
-  rewardName: "CV Points",
-  rewardPer: "₹100",
-  rewardProgramName: "CV",
-};
-
 export const Velocity: Partnership = {
   accountFields: [
     "account_id",


### PR DESCRIPTION
We are ending the partnership with Club Vistara and the company itself no longer exists as it was aquired by Air India. This means we want to remove references to it across the stack.

This PR removes the references in lib-partnerships